### PR TITLE
Data exchange integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ ff stop <stack_name>
 
 ## Clear all data from a stack
 
-This command clears all data in a stack, but leaves the stack itself. This is useful for testing when you want to start with a clean slate but don't want to actually recreate the resources in the stack itself. The stack must be stopped to run this command.
+This command clears all data in a stack, but leaves the stack itself. This is useful for testing when you want to start with a clean slate but don't want to actually recreate the resources in the stack itself. Note: this will also stop the stack if it is running.
 
 ```
 $ ff reset <stack_name>
@@ -53,7 +53,7 @@ $ ff reset <stack_name>
 
 ## Completely delete a stack
 
-This command will completely delete a stack, including all of its data and configuration. The stack must be stopped to run this command.
+This command will completely delete a stack, including all of its data and configuration.
 
 ```
 $ ff remove <stack_name>

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -85,7 +85,9 @@ var initCmd = &cobra.Command{
 		}
 		memberCount, _ := strconv.Atoi(memberCountInput)
 
-		stacks.InitStack(stackName, memberCount)
+		if err := stacks.InitStack(stackName, memberCount); err != nil {
+			return err
+		}
 
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n\n", stackName, rootCmd.Use, stackName)
 		return nil

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -30,10 +30,10 @@ var resetCmd = &cobra.Command{
 	Short: "Clear all data in a stack",
 	Long: `Clear all data in a stack
 
-This command clears all data in a stack, but leaves the stack itself.
+This command clears all data in a stack, but leaves the stack configuration.
 This is useful for testing when you want to start with a clean slate
 but don't want to actually recreate the resources in the stack itself.
-The stack must be stopped to run this command.
+Note: this will also stop the stack if it is running.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
@@ -66,7 +66,12 @@ The stack must be stopped to run this command.
 			return err
 		} else {
 			fmt.Printf("resetting FireFly stack '%s'... ", stackName)
-			stack.ResetStack(verbose)
+			if err := stack.StopStack(verbose); err != nil {
+				return err
+			}
+			if err := stack.ResetStack(verbose); err != nil {
+				return err
+			}
 			fmt.Println("done")
 		}
 

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -17,9 +17,7 @@ package cmd
 
 import (
 	"fmt"
-	"path"
 
-	"github.com/kaleido-io/firefly-cli/internal/docker"
 	"github.com/kaleido-io/firefly-cli/internal/stacks"
 	"github.com/spf13/cobra"
 )
@@ -39,14 +37,17 @@ var stopCmd = &cobra.Command{
 		} else if !exists {
 			return fmt.Errorf("stack '%s' does not exist", stackName)
 		}
-		workingDir := path.Join(stacks.StacksDir, stackName)
-		fmt.Printf("stopping stack '%s'... ", stackName)
-		if err := docker.RunDockerComposeCommand(workingDir, verbose, verbose, "stop"); err != nil {
-			return fmt.Errorf("command finished with error: %v", err)
+
+		if stack, err := stacks.LoadStack(stackName); err != nil {
+			return err
 		} else {
+			fmt.Printf("stopping stack '%s'... ", stackName)
+			if err := stack.StopStack(verbose); err != nil {
+				return err
+			}
 			fmt.Print("done\n")
+			return nil
 		}
-		return nil
 	},
 }
 

--- a/internal/stacks/dataExchange.go
+++ b/internal/stacks/dataExchange.go
@@ -15,6 +15,7 @@ import (
 
 type DataExchangeListenerConfig struct {
 	Hostname string `json:"hostname,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
 	Port     int    `json:"port,omitempty"`
 }
 
@@ -52,6 +53,7 @@ func (s *Stack) GenerateDataExchangeConfig(memberId string) *DataExchangeConfig 
 		P2P: &DataExchangeListenerConfig{
 			Hostname: "0.0.0.0",
 			Port:     3001,
+			Endpoint: fmt.Sprintf("https://dataexchange_%s:3001", memberId),
 		},
 		Peers: []*PeerConfig{},
 	}

--- a/internal/stacks/dataExchange.go
+++ b/internal/stacks/dataExchange.go
@@ -1,0 +1,139 @@
+package stacks
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+)
+
+type DataExchangeListenerConfig struct {
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+}
+
+type PeerConfig struct {
+	ID       string `json:"id,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+}
+
+type DataExchangeConfig struct {
+	API   *DataExchangeListenerConfig `json:"api,omitempty"`
+	P2P   *DataExchangeListenerConfig `json:"p2p,omitempty"`
+	Peers []*PeerConfig               `json:"peers"`
+}
+
+func (s *Stack) GenerateDataExchangeConfig(memberId string) *DataExchangeConfig {
+
+	peers := make([]*PeerConfig, len(s.Members)-1)
+	i := 0
+
+	for _, member := range s.Members {
+		if member.ID != memberId {
+			peers[i] = &PeerConfig{
+				ID:       member.ID,
+				Endpoint: fmt.Sprintf("https://dataexchange_%s:3001", member.ID),
+			}
+
+		}
+	}
+
+	return &DataExchangeConfig{
+		API: &DataExchangeListenerConfig{
+			Hostname: "0.0.0.0",
+			Port:     3000,
+		},
+		P2P: &DataExchangeListenerConfig{
+			Hostname: "0.0.0.0",
+			Port:     3001,
+		},
+		Peers: []*PeerConfig{},
+	}
+}
+
+func CreateCert(memberId string) (*bytes.Buffer, *bytes.Buffer, error) {
+	ca := &x509.Certificate{
+		SerialNumber: big.NewInt(2019),
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{memberId},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	caPEM := new(bytes.Buffer)
+	pem.Encode(caPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: caBytes,
+	})
+
+	caPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(caPrivKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
+	})
+
+	cert := &x509.Certificate{
+		SerialNumber: big.NewInt(1658),
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{memberId},
+		},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().AddDate(10, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+
+	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPEM := new(bytes.Buffer)
+	pem.Encode(certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	})
+
+	privKeyBytes := x509.MarshalPKCS1PrivateKey(certPrivKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certPrivKeyPEM := new(bytes.Buffer)
+	pem.Encode(certPrivKeyPEM, &pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: privKeyBytes,
+	})
+
+	return certPEM, certPrivKeyPEM, nil
+}

--- a/internal/stacks/dataExchange.go
+++ b/internal/stacks/dataExchange.go
@@ -59,11 +59,11 @@ func (s *Stack) GenerateDataExchangeHTTPSConfig(memberId string) *DataExchangePe
 	}
 }
 
-func CreateCert(memberId string) (*bytes.Buffer, *bytes.Buffer, error) {
+func CreateCert(hostname, memberId string) (*bytes.Buffer, *bytes.Buffer, error) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),
 		Subject: pkix.Name{
-			CommonName:   "localhost",
+			CommonName:   hostname,
 			Organization: []string{memberId},
 		},
 		NotBefore:             time.Now(),

--- a/internal/stacks/dataExchange.go
+++ b/internal/stacks/dataExchange.go
@@ -24,13 +24,13 @@ type PeerConfig struct {
 	Endpoint string `json:"endpoint,omitempty"`
 }
 
-type DataExchangeConfig struct {
+type DataExchangePeerConfig struct {
 	API   *DataExchangeListenerConfig `json:"api,omitempty"`
 	P2P   *DataExchangeListenerConfig `json:"p2p,omitempty"`
 	Peers []*PeerConfig               `json:"peers"`
 }
 
-func (s *Stack) GenerateDataExchangeConfig(memberId string) *DataExchangeConfig {
+func (s *Stack) GenerateDataExchangeHTTPSConfig(memberId string) *DataExchangePeerConfig {
 
 	peers := make([]*PeerConfig, len(s.Members)-1)
 	i := 0
@@ -45,7 +45,7 @@ func (s *Stack) GenerateDataExchangeConfig(memberId string) *DataExchangeConfig 
 		}
 	}
 
-	return &DataExchangeConfig{
+	return &DataExchangePeerConfig{
 		API: &DataExchangeListenerConfig{
 			Hostname: "0.0.0.0",
 			Port:     3000,

--- a/internal/stacks/dataExchange.go
+++ b/internal/stacks/dataExchange.go
@@ -1,16 +1,7 @@
 package stacks
 
 import (
-	"bytes"
-	"crypto/rand"
-	"crypto/rsa"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
 	"fmt"
-	"math/big"
-	"net"
-	"time"
 )
 
 type DataExchangeListenerConfig struct {
@@ -31,20 +22,6 @@ type DataExchangePeerConfig struct {
 }
 
 func (s *Stack) GenerateDataExchangeHTTPSConfig(memberId string) *DataExchangePeerConfig {
-
-	peers := make([]*PeerConfig, len(s.Members)-1)
-	i := 0
-
-	for _, member := range s.Members {
-		if member.ID != memberId {
-			peers[i] = &PeerConfig{
-				ID:       member.ID,
-				Endpoint: fmt.Sprintf("https://dataexchange_%s:3001", member.ID),
-			}
-
-		}
-	}
-
 	return &DataExchangePeerConfig{
 		API: &DataExchangeListenerConfig{
 			Hostname: "0.0.0.0",
@@ -57,85 +34,4 @@ func (s *Stack) GenerateDataExchangeHTTPSConfig(memberId string) *DataExchangePe
 		},
 		Peers: []*PeerConfig{},
 	}
-}
-
-func CreateCert(hostname, memberId string) (*bytes.Buffer, *bytes.Buffer, error) {
-	ca := &x509.Certificate{
-		SerialNumber: big.NewInt(2019),
-		Subject: pkix.Name{
-			CommonName:   hostname,
-			Organization: []string{memberId},
-		},
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().AddDate(10, 0, 0),
-		IsCA:                  true,
-		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-	}
-
-	caPrivKey, err := rsa.GenerateKey(rand.Reader, 4096)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	caBytes, err := x509.CreateCertificate(rand.Reader, ca, ca, &caPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	caPEM := new(bytes.Buffer)
-	pem.Encode(caPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: caBytes,
-	})
-
-	caPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(caPrivKeyPEM, &pem.Block{
-		Type:  "RSA PRIVATE KEY",
-		Bytes: x509.MarshalPKCS1PrivateKey(caPrivKey),
-	})
-
-	cert := &x509.Certificate{
-		SerialNumber: big.NewInt(1658),
-		Subject: pkix.Name{
-			CommonName:   "localhost",
-			Organization: []string{memberId},
-		},
-		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
-		NotBefore:    time.Now(),
-		NotAfter:     time.Now().AddDate(10, 0, 0),
-		SubjectKeyId: []byte{1, 2, 3, 4, 6},
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-	}
-
-	certPrivKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certBytes, err := x509.CreateCertificate(rand.Reader, cert, ca, &certPrivKey.PublicKey, caPrivKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certPEM := new(bytes.Buffer)
-	pem.Encode(certPEM, &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: certBytes,
-	})
-
-	privKeyBytes := x509.MarshalPKCS1PrivateKey(certPrivKey)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	certPrivKeyPEM := new(bytes.Buffer)
-	pem.Encode(certPrivKeyPEM, &pem.Block{
-		Type:  "PRIVATE KEY",
-		Bytes: privKeyBytes,
-	})
-
-	return certPEM, certPrivKeyPEM, nil
 }

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -68,7 +68,7 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 	for _, member := range stack.Members {
 		compose.Services["firefly_core_"+member.ID] = &Service{
 			Image:   "kaleidoinc/firefly",
-			Ports:   []string{fmt.Sprint(member.ExposedFireflyPort) + ":5000"},
+			Ports:   []string{fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort)},
 			Volumes: []string{path.Join(stackDir, "firefly_"+member.ID+".core") + ":/etc/firefly/firefly.core"},
 			DependsOn: map[string]map[string]string{
 				"postgres_" + member.ID:   {"condition": "service_healthy"},

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -79,6 +79,7 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 
 		compose.Services["postgres_"+member.ID] = &Service{
 			Image:       "postgres",
+			Ports:       []string{fmt.Sprint(member.ExposedPostgresPort) + ":5432"},
 			Environment: map[string]string{"POSTGRES_PASSWORD": "f1refly"},
 			HealthCheck: &HealthCheck{
 				Test:     []string{"CMD-SHELL", "pg_isready -U postgres"},
@@ -99,6 +100,10 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 
 		compose.Services["ipfs_"+member.ID] = &Service{
 			Image: "ipfs/go-ipfs",
+			Ports: []string{
+				fmt.Sprint(member.ExposedIPFSApiPort) + ":5000",
+				fmt.Sprint(member.ExposedIPFSGWPort) + ":8080",
+			},
 			Environment: map[string]string{
 				"IPFS_SWARM_KEY":    stack.SwarmKey,
 				"LIBP2P_FORCE_PNET": "1",
@@ -108,6 +113,7 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 
 		compose.Services["dataexchange_"+member.ID] = &Service{
 			Image:   "kaleidoinc/firefly-dataexchange-https",
+			Ports:   []string{fmt.Sprint(member.ExposedDataexchangePort) + ":3000"},
 			Volumes: []string{path.Join(dataDir, "dataexchange_"+member.ID) + ":/data"},
 			Logging: standardLogOptions,
 		}

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -105,6 +105,12 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 			},
 			Logging: standardLogOptions,
 		}
+
+		compose.Services["dataexchange_"+member.ID] = &Service{
+			Image:   "kaleidoinc/firefly-dataexchange-https",
+			Volumes: []string{path.Join(dataDir, "dataexchange_"+member.ID) + ":/data"},
+			Logging: standardLogOptions,
+		}
 	}
 
 	return compose

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -1,6 +1,7 @@
 package stacks
 
 import (
+	"fmt"
 	"io/ioutil"
 
 	"gopkg.in/yaml.v2"
@@ -30,10 +31,11 @@ type UIConfig struct {
 }
 
 type NodeConfig struct {
-	Identity string `yaml:"identity,omitempty"`
+	Name string `yaml:"name,omitempty"`
 }
 
 type OrgConfig struct {
+	Name     string `yaml:"name,omitempty"`
 	Identity string `yaml:"identity,omitempty"`
 }
 
@@ -52,6 +54,11 @@ type EthereumConfig struct {
 type BlockchainConfig struct {
 	Type     string          `yaml:"type,omitempty"`
 	Ethereum *EthereumConfig `yaml:"ethereum,omitempty"`
+}
+
+type DataExchangeConfig struct {
+	Type  string              `yaml:"type,omitempty"`
+	HTTPS *HttpEndpointConfig `yaml:"https,omitempty"`
 }
 
 type PostgresConfig struct {
@@ -89,7 +96,7 @@ type FireflyConfig struct {
 	Blockchain   *BlockchainConfig    `yaml:"blockchain,omitempty"`
 	Database     *DatabaseConfig      `yaml:"database,omitempty"`
 	P2PFS        *PublicStorageConfig `yaml:"publicstorage,omitempty"`
-	DataExchange *HttpEndpointConfig  `yaml:"dataexchange,omitempty"`
+	DataExchange *DataExchangeConfig  `yaml:"dataexchange,omitempty"`
 }
 
 func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
@@ -111,9 +118,10 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 				Path: "./frontend",
 			},
 			Node: &NodeConfig{
-				Identity: member.Address,
+				Name: fmt.Sprintf("node_%s", member.ID),
 			},
 			Org: &OrgConfig{
+				Name:     fmt.Sprintf("org_%s", member.ID),
 				Identity: member.Address,
 			},
 			Blockchain: &BlockchainConfig{
@@ -147,8 +155,10 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 					},
 				},
 			},
-			DataExchange: &HttpEndpointConfig{
-				URL: "http://dataexchange_" + member.ID + ":3000",
+			DataExchange: &DataExchangeConfig{
+				HTTPS: &HttpEndpointConfig{
+					URL: "http://dataexchange_" + member.ID + ":3000",
+				},
 			},
 		}
 	}

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -80,15 +80,16 @@ type FireflyIPFSConfig struct {
 }
 
 type FireflyConfig struct {
-	Log        *LogConfig           `yaml:"log,omitempty"`
-	Debug      *HttpServerConfig    `yaml:"debug,omitempty"`
-	HTTP       *HttpServerConfig    `yaml:"http,omitempty"`
-	UI         *UIConfig            `yaml:"ui,omitempty"`
-	Node       *NodeConfig          `yaml:"node,omitempty"`
-	Org        *OrgConfig           `yaml:"org,omitempty"`
-	Blockchain *BlockchainConfig    `yaml:"blockchain,omitempty"`
-	Database   *DatabaseConfig      `yaml:"database,omitempty"`
-	P2PFS      *PublicStorageConfig `yaml:"publicstorage,omitempty"`
+	Log          *LogConfig           `yaml:"log,omitempty"`
+	Debug        *HttpServerConfig    `yaml:"debug,omitempty"`
+	HTTP         *HttpServerConfig    `yaml:"http,omitempty"`
+	UI           *UIConfig            `yaml:"ui,omitempty"`
+	Node         *NodeConfig          `yaml:"node,omitempty"`
+	Org          *OrgConfig           `yaml:"org,omitempty"`
+	Blockchain   *BlockchainConfig    `yaml:"blockchain,omitempty"`
+	Database     *DatabaseConfig      `yaml:"database,omitempty"`
+	P2PFS        *PublicStorageConfig `yaml:"publicstorage,omitempty"`
+	DataExchange *HttpEndpointConfig  `yaml:"dataexchange,omitempty"`
 }
 
 func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
@@ -146,6 +147,9 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 					},
 				},
 			},
+			DataExchange: &HttpEndpointConfig{
+				URL: "http://dataexchange_" + member.ID + ":3000",
+			},
 		}
 	}
 	return configs
@@ -165,7 +169,6 @@ func WriteFireflyConfig(config *FireflyConfig, filePath string) error {
 	if bytes, err := yaml.Marshal(config); err != nil {
 		return err
 	} else {
-		ioutil.WriteFile(filePath, bytes, 0755)
-		return nil
+		return ioutil.WriteFile(filePath, bytes, 0755)
 	}
 }

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -111,7 +111,7 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 				Port: 6060,
 			},
 			HTTP: &HttpServerConfig{
-				Port:    5000,
+				Port:    member.ExposedFireflyPort,
 				Address: "0.0.0.0",
 			},
 			UI: &UIConfig{

--- a/internal/stacks/fireflyIdentity.go
+++ b/internal/stacks/fireflyIdentity.go
@@ -1,0 +1,105 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+func (s *Stack) httpJSON(method, url string, body, result interface{}) (err error) {
+	if body == nil {
+		body = make(map[string]interface{})
+	}
+	if result == nil {
+		result = make(map[string]interface{})
+	}
+
+	var requestBody []byte
+	if method != http.MethodGet && method != http.MethodDelete {
+		requestBody, err = json.Marshal(&body)
+		if err != nil {
+			return err
+		}
+	}
+
+	req, err := http.NewRequest(method, url, bytes.NewReader(requestBody))
+	req.Header.Set("Content-Type", "application/json")
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		b, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("%s returned %d: %s", url, resp.StatusCode, b)
+	}
+
+	return json.NewDecoder(resp.Body).Decode(&result)
+}
+
+func (s *Stack) registerFireflyIdentities(spin *spinner.Spinner, verbose bool) error {
+	for _, member := range s.Members {
+		orgName := fmt.Sprintf("org_%s", member.ID)
+		nodeName := fmt.Sprintf("node_%s", member.ID)
+		ffURL := fmt.Sprintf("http://localhost:%d/api/v1", member.ExposedFireflyPort)
+		updateStatus(fmt.Sprintf("registering %s and %s", orgName, nodeName), spin)
+
+		registerOrgURL := fmt.Sprintf("%s/network/register/node/organization", ffURL)
+		err := s.httpJSON(http.MethodPost, registerOrgURL, nil, nil)
+		if err != nil {
+			return err
+		}
+
+		foundOrg := false
+		for !foundOrg {
+			type establishedOrg struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}
+			orgURL := fmt.Sprintf("%s/network/organizations", ffURL)
+			var orgs []establishedOrg
+			err := s.httpJSON(http.MethodGet, orgURL, nil, &orgs)
+			if err != nil {
+				return nil
+			}
+			for _, o := range orgs {
+				foundOrg = foundOrg || o.Name == orgName
+			}
+			if !foundOrg {
+				time.Sleep(1 * time.Second)
+			}
+		}
+
+		registerNodeURL := fmt.Sprintf("%s/network/register/node", ffURL)
+		err = s.httpJSON(http.MethodPost, registerNodeURL, nil, nil)
+		if err != nil {
+			return nil
+		}
+	}
+	return nil
+}

--- a/internal/stacks/fireflyIdentity.go
+++ b/internal/stacks/fireflyIdentity.go
@@ -44,6 +44,9 @@ func (s *Stack) httpJSON(method, url string, body, result interface{}) (err erro
 	}
 
 	req, err := http.NewRequest(method, url, bytes.NewReader(requestBody))
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return err

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -30,13 +30,17 @@ type Stack struct {
 }
 
 type Member struct {
-	ID                    string `json:"id,omitempty"`
-	Index                 *int   `json:"index,omitempty"`
-	Address               string `json:"address,omitempty"`
-	PrivateKey            string `json:"privateKey,omitempty"`
-	ExposedFireflyPort    int    `json:"exposedFireflyPort,omitempty"`
-	ExposedEthconnectPort int    `json:"exposedEthconnectPort,omitempty"`
-	ExposedUIPort         int    `json:"exposedUiPort ,omitempty"`
+	ID                      string `json:"id,omitempty"`
+	Index                   *int   `json:"index,omitempty"`
+	Address                 string `json:"address,omitempty"`
+	PrivateKey              string `json:"privateKey,omitempty"`
+	ExposedFireflyPort      int    `json:"exposedFireflyPort,omitempty"`
+	ExposedEthconnectPort   int    `json:"exposedEthconnectPort,omitempty"`
+	ExposedPostgresPort     int    `json:"exposedPostgresPort,omitempty"`
+	ExposedDataexchangePort int    `json:"exposedDataexchangePort,omitempty"`
+	ExposedIPFSApiPort      int    `json:"exposedIPFSApiPort,omitempty`
+	ExposedIPFSGWPort       int    `json:"exposedIPFSGWPort,omitempty`
+	ExposedUIPort           int    `json:"exposedUiPort ,omitempty"`
 }
 
 func InitStack(stackName string, memberCount int) error {
@@ -163,13 +167,17 @@ func createMember(id string, index int) *Member {
 	encodedAddress := "0x" + hex.EncodeToString(hash.Sum(nil)[12:32])
 
 	return &Member{
-		ID:                    id,
-		Index:                 &index,
-		Address:               encodedAddress,
-		PrivateKey:            encodedPrivateKey,
-		ExposedFireflyPort:    5000 + index,
-		ExposedEthconnectPort: 8080 + index,
-		ExposedUIPort:         3000 + index,
+		ID:                      id,
+		Index:                   &index,
+		Address:                 encodedAddress,
+		PrivateKey:              encodedPrivateKey,
+		ExposedFireflyPort:      5000 + index,
+		ExposedEthconnectPort:   8080 + index,
+		ExposedUIPort:           3000 + index,
+		ExposedPostgresPort:     5434 + index,
+		ExposedDataexchangePort: 3020 + index,
+		ExposedIPFSApiPort:      6000 + index,
+		ExposedIPFSGWPort:       6100 + index,
 	}
 }
 

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -138,7 +138,7 @@ func (s *Stack) writeDataExchangeCerts() error {
 	for _, member := range s.Members {
 
 		// TODO: remove dependency on openssl here
-		opensslCmd := exec.Command("openssl", "req", "-new", "-x509", "-nodes", "-days", "365", "-subj", fmt.Sprintf("/CN=localhost/O=member_%s", member.ID), "-keyout", "key.pem", "-out", "cert.pem")
+		opensslCmd := exec.Command("openssl", "req", "-new", "-x509", "-nodes", "-days", "365", "-subj", fmt.Sprintf("/CN=dataexchange_%s/O=member_%s", member.ID, member.ID), "-keyout", "key.pem", "-out", "cert.pem")
 		opensslCmd.Dir = path.Join(stackDir, "data", "dataexchange_"+member.ID)
 		if err := opensslCmd.Run(); err != nil {
 			return err

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -140,7 +140,7 @@ func (s *Stack) writeDataExchangeCerts() error {
 			return err
 		}
 
-		dataExchangeConfig := s.GenerateDataExchangeConfig(member.ID)
+		dataExchangeConfig := s.GenerateDataExchangeHTTPSConfig(member.ID)
 		configBytes, err := json.Marshal(dataExchangeConfig)
 		if err != nil {
 			log.Fatal(err)
@@ -243,6 +243,10 @@ func (s *Stack) runFirstTimeSetup(spin *spinner.Spinner, verbose bool) error {
 	if err := s.deployContracts(spin, verbose); err != nil {
 		return err
 	}
+	updateStatus("registering FireFly identities", spin)
+	if err := s.registerFireflyIdentities(spin, verbose); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -313,6 +317,7 @@ func (s *Stack) deployContracts(spin *spinner.Spinner, verbose bool) error {
 	if err := s.patchConfigAndRestartFireflyNodes(verbose); err != nil {
 		return err
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR adds support for https://github.com/hyperledger-labs/firefly-dataexchange-https.

Other notable improvements include:

- More error propagation throughout
- The `reset` and `remove` commands automatically perform `stop` first so you don't have to. This prevents stacks from getting into weird states where their data has been deleted but the containers themselves haven't been.