### PR TITLE
Capture exit code and stdout/stderr if commands fail and print for users

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -5,16 +5,18 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 )
 
 func RunDockerCommand(workingDir string, showCommand bool, pipeStdout bool, command ...string) error {
 	dockerCmd := exec.Command("docker", command...)
 	dockerCmd.Dir = workingDir
+	dockerCmd.StderrPipe()
 	return runCommand(dockerCmd, showCommand, pipeStdout, command...)
 }
 
 func RunDockerComposeCommand(workingDir string, showCommand bool, pipeStdout bool, command ...string) error {
-	dockerCmd := exec.Command("docker-compose", command...)
+	dockerCmd := exec.Command("docker", append([]string{"compose"}, command...)...)
 	dockerCmd.Dir = workingDir
 	return runCommand(dockerCmd, showCommand, pipeStdout, command...)
 }
@@ -23,31 +25,43 @@ func runCommand(cmd *exec.Cmd, showCommand bool, pipeStdout bool, command ...str
 	if showCommand {
 		fmt.Println(cmd.String())
 	}
+	outputBuff := strings.Builder{}
 	stdoutChan := make(chan string)
 	stderrChan := make(chan string)
 	errChan := make(chan error)
 	go pipeCommand(cmd, stdoutChan, stderrChan, errChan)
 
+outputCapture:
 	for {
 		select {
 		case s, ok := <-stdoutChan:
 			if pipeStdout {
 				if !ok {
-					return nil
+					break outputCapture
 				}
 				fmt.Print(s)
+			} else {
+				outputBuff.WriteString(s)
 			}
 		case s, ok := <-stderrChan:
 			if !ok {
-				return nil
+				break outputCapture
 			}
 			if pipeStdout {
 				fmt.Print(s)
+			} else {
+				outputBuff.WriteString(s)
 			}
 		case err := <-errChan:
 			return err
 		}
 	}
+	cmd.Wait()
+	statusCode := cmd.ProcessState.ExitCode()
+	if statusCode != 0 {
+		return fmt.Errorf("%s\nFailed [%d] %s", strings.Join(cmd.Args, " "), statusCode, outputBuff.String())
+	}
+	return nil
 }
 
 func pipeCommand(cmd *exec.Cmd, stdoutChan chan string, stderrChan chan string, errChan chan error) {

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -11,7 +11,6 @@ import (
 func RunDockerCommand(workingDir string, showCommand bool, pipeStdout bool, command ...string) error {
 	dockerCmd := exec.Command("docker", command...)
 	dockerCmd.Dir = workingDir
-	dockerCmd.StderrPipe()
 	return runCommand(dockerCmd, showCommand, pipeStdout, command...)
 }
 

--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -15,7 +15,7 @@ func RunDockerCommand(workingDir string, showCommand bool, pipeStdout bool, comm
 }
 
 func RunDockerComposeCommand(workingDir string, showCommand bool, pipeStdout bool, command ...string) error {
-	dockerCmd := exec.Command("docker", append([]string{"compose"}, command...)...)
+	dockerCmd := exec.Command("docker-compose", command...)
 	dockerCmd.Dir = workingDir
 	return runCommand(dockerCmd, showCommand, pipeStdout, command...)
 }


### PR DESCRIPTION
On my machine `docker-compose` now fails with:
`Docker Compose is now in the Docker CLI, try 'docker compose up'`

In order to work this out, I found it easiest to implement #27 