### PR TITLE
Add upgrade, info, and ls commands

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// infoCmd represents the stop command
 var infoCmd = &cobra.Command{
 	Use:   "info <stack_name>",
 	Short: "Get info about a stack",
@@ -52,14 +51,4 @@ var infoCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(infoCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,65 @@
+/*
+Copyright © 2021 Kaleido, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/hyperledger-labs/firefly-cli/internal/stacks"
+	"github.com/spf13/cobra"
+)
+
+// infoCmd represents the stop command
+var infoCmd = &cobra.Command{
+	Use:   "info <stack_name>",
+	Short: "Get info about a stack",
+	Long: `Get info about a stack such as each container name
+	and image version.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("no stack specified")
+		}
+		stackName := args[0]
+		if exists, err := stacks.CheckExists(stackName); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("stack '%s' does not exist", stackName)
+		}
+
+		if stack, err := stacks.LoadStack(stackName); err != nil {
+			return err
+		} else {
+			if err := stack.PrintStackInfo(verbose); err != nil {
+				return err
+			}
+			return nil
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(infoCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// infoCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// infoCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"path"
 	"strconv"
 
 	"github.com/nguyer/promptui"
@@ -90,6 +91,7 @@ var initCmd = &cobra.Command{
 		}
 
 		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n\n", stackName, rootCmd.Use, stackName)
+		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", path.Join(stacks.StacksDir, stackName, "docker-compose.yml"))
 		return nil
 	},
 }

--- a/cmd/logs.go
+++ b/cmd/logs.go
@@ -64,16 +64,5 @@ output with the -f flag.`,
 
 func init() {
 	rootCmd.AddCommand(logsCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// logsCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// logsCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-
 	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "follow log output")
 }

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -1,0 +1,47 @@
+/*
+Copyright © 2021 Kaleido, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger-labs/firefly-cli/internal/stacks"
+)
+
+var lsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "list stacks",
+	Long:  `List stacks`,
+	Args:  cobra.MaximumNArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if stacks, err := stacks.ListStacks(); err != nil {
+			return err
+		} else {
+			fmt.Print("FireFly Stacks:\n\n")
+			for _, s := range stacks {
+				fmt.Println(s)
+			}
+			fmt.Print("\n")
+		}
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(lsCmd)
+}

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -26,7 +26,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// removeCmd represents the remove command
 var removeCmd = &cobra.Command{
 	Use:   "remove <stack_name>",
 	Short: "Completely remove a stack",

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -72,7 +72,7 @@ Note: this will also stop the stack if it is running.
 			if err := stack.ResetStack(verbose); err != nil {
 				return err
 			}
-			fmt.Println("done")
+			fmt.Printf("done\n\nYour stack has been reset. To start your stack run:\n\n%s start %s\n\n", rootCmd.Use, stackName)
 		}
 
 		return nil

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// resetCmd represents the reset command
 var resetCmd = &cobra.Command{
 	Use:   "reset <stack_name>",
 	Short: "Clear all data in a stack",

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// startCmd represents the start command
 var startCmd = &cobra.Command{
 	Use:   "start <stack_name>",
 	Short: "Start a stack",
@@ -58,14 +57,4 @@ This command will start a stack and run it in the background.
 
 func init() {
 	rootCmd.AddCommand(startCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// startCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// startCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -53,14 +53,4 @@ var stopCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(stopCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// stopCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// stopCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2021 Kaleido, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/hyperledger-labs/firefly-cli/internal/stacks"
+	"github.com/spf13/cobra"
+)
+
+// upgradeCmd represents the stop command
+var upgradeCmd = &cobra.Command{
+	Use:   "upgrade <stack_name>",
+	Short: "Upgrade a stack",
+	Long: `Upgrade a stack by pulling newer images.
+	This operation will restart the stack if running.
+	If certain containers were pinned to a specific image at init,
+	this command will have no effect on those containers.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 0 {
+			return fmt.Errorf("no stack specified")
+		}
+		stackName := args[0]
+		if exists, err := stacks.CheckExists(stackName); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("stack '%s' does not exist", stackName)
+		}
+
+		if stack, err := stacks.LoadStack(stackName); err != nil {
+			return err
+		} else {
+			fmt.Printf("upgrading stack '%s'... ", stackName)
+			if err := stack.UpgradeStack(verbose); err != nil {
+				return err
+			}
+			fmt.Printf("done\n\nYour stack has been upgraded. To start your upgraded stack run:\n\n%s start %s\n\n", rootCmd.Use, stackName)
+			return nil
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(upgradeCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// upgradeCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// upgradeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,7 +22,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// upgradeCmd represents the stop command
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade <stack_name>",
 	Short: "Upgrade a stack",
@@ -56,14 +55,4 @@ var upgradeCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// upgradeCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// upgradeCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -71,21 +71,26 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 			Ports:   []string{fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort)},
 			Volumes: []string{path.Join(stackDir, "firefly_"+member.ID+".core") + ":/etc/firefly/firefly.core"},
 			DependsOn: map[string]map[string]string{
-				"postgres_" + member.ID:   {"condition": "service_healthy"},
-				"ethconnect_" + member.ID: {"condition": "service_started"},
+				"postgres_" + member.ID:     {"condition": "service_healthy"},
+				"ethconnect_" + member.ID:   {"condition": "service_started"},
+				"dataexchange_" + member.ID: {"condition": "service_started"},
 			},
 			Logging: standardLogOptions,
 		}
 
 		compose.Services["postgres_"+member.ID] = &Service{
-			Image:       "postgres",
-			Ports:       []string{fmt.Sprint(member.ExposedPostgresPort) + ":5432"},
-			Environment: map[string]string{"POSTGRES_PASSWORD": "f1refly"},
+			Image: "postgres",
+			Ports: []string{fmt.Sprint(member.ExposedPostgresPort) + ":5432"},
+			Environment: map[string]string{
+				"POSTGRES_PASSWORD": "f1refly",
+				"PGDATA":            "/var/lib/postgresql/data/pgdata",
+			},
+			Volumes: []string{path.Join(dataDir, "postgres_"+member.ID) + ":/var/lib/postgresql/data"},
 			HealthCheck: &HealthCheck{
 				Test:     []string{"CMD-SHELL", "pg_isready -U postgres"},
-				Interval: "5s",
+				Interval: "2s",
 				Timeout:  "5s",
-				Retries:  5,
+				Retries:  60,
 			},
 			Logging: standardLogOptions,
 		}
@@ -95,7 +100,11 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 			Command:   "rest -U http://127.0.0.1:8080 -I ./abis -r http://ganache:8545 -E ./events -d 3",
 			DependsOn: map[string]map[string]string{"ganache": {"condition": "service_started"}},
 			Ports:     []string{fmt.Sprint(member.ExposedEthconnectPort) + ":8080"},
-			Logging:   standardLogOptions,
+			Volumes: []string{
+				path.Join(dataDir, "ethconnect_"+member.ID, "abis") + ":/ethconnect/abis",
+				path.Join(dataDir, "ethconnect_"+member.ID, "events") + ":/ethconnect/events",
+			},
+			Logging: standardLogOptions,
 		}
 
 		compose.Services["ipfs_"+member.ID] = &Service{
@@ -107,6 +116,10 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 			Environment: map[string]string{
 				"IPFS_SWARM_KEY":    stack.SwarmKey,
 				"LIBP2P_FORCE_PNET": "1",
+			},
+			Volumes: []string{
+				path.Join(dataDir, "ipfs_"+member.ID, "staging") + "/export",
+				path.Join(dataDir, "ipfs_"+member.ID, "data") + "/data/ipfs",
 			},
 			Logging: standardLogOptions,
 		}


### PR DESCRIPTION
This PR adds `ff upgrade` `ff info`, and `ff ls` commands. There are probably more things we want to add to `info` but this is a start. Right now it shows you the versions of the images your stack is using and the status of any running containers. It also shows you the path to the `docker-compose.yml` if you want to go tinker with it. (`ff init` also prints this out when it finishes now too).

`ff upgrade` can be used to grab the latest versions of each image used in the stack. This should not result in data loss in the stack, so it should be useful for testing backwards compatibility of apps built on FireFly. Data loss during upgrade is prevented due to the fact that all data generated by the system has moved to the `~/.firefly/stacks/<stack_name>/data` directory now.

`ff ls` will list the stacks you have on your machine.

This PR should satisfy both https://github.com/hyperledger-labs/firefly-cli/issues/24 and https://github.com/hyperledger-labs/firefly-cli/issues/26