### PR TITLE
Retry registration HTTP requests

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -90,7 +90,7 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n\n", stackName, rootCmd.Use, stackName)
+		fmt.Printf("Stack '%s' created!\nTo start your new stack run:\n\n%s start %s\n", stackName, rootCmd.Use, stackName)
 		fmt.Printf("\nYour docker compose file for this stack can be found at: %s\n\n", path.Join(stacks.StacksDir, stackName, "docker-compose.yml"))
 		return nil
 	},


### PR DESCRIPTION
If HTTP requests for registration fail, it causes problems setting up the environment. This wraps those HTTP requests in a retry loop (up to 30 seconds) which should prevent errors due to slight timing inconsistencies in processes startup.