### PR TITLE
Suggested improvements for local dev

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -28,6 +28,8 @@ import (
 	"github.com/hyperledger-labs/firefly-cli/internal/stacks"
 )
 
+var initOptions stacks.InitOptions
+
 var initCmd = &cobra.Command{
 	Use:   "init [stack_name] [member_count]",
 	Short: "Create a new FireFly local dev stack",
@@ -86,7 +88,7 @@ var initCmd = &cobra.Command{
 		}
 		memberCount, _ := strconv.Atoi(memberCountInput)
 
-		if err := stacks.InitStack(stackName, memberCount); err != nil {
+		if err := stacks.InitStack(stackName, memberCount, &initOptions); err != nil {
 			return err
 		}
 
@@ -97,5 +99,8 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
+	initCmd.Flags().IntVarP(&initOptions.FireFlyBasePort, "firefly-base-port", "p", 5000, "Mapped port base of FireFly core API (1 added for each member)")
+	initCmd.Flags().IntVarP(&initOptions.ServicesBasePort, "services-base-port", "s", 5100, "Mapped port base of services (100 added for each member)")
+
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var startOptions stacks.StartOptions
+
 var startCmd = &cobra.Command{
 	Use:   "start <stack_name>",
 	Short: "Start a stack",
@@ -42,7 +44,7 @@ This command will start a stack and run it in the background.
 			return err
 		}
 
-		if err = stack.StartStack(fancyFeatures, verbose); err != nil {
+		if err = stack.StartStack(fancyFeatures, verbose, &startOptions); err != nil {
 			return err
 		} else {
 			fmt.Print("\n\n")
@@ -56,5 +58,7 @@ This command will start a stack and run it in the background.
 }
 
 func init() {
+	startCmd.Flags().BoolVarP(&startOptions.NoPull, "no-pull", "n", false, "Do not pull latest images when starting")
+
 	rootCmd.AddCommand(startCmd)
 }

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -63,6 +63,7 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 		Command: ganacheCommand,
 		Volumes: []string{dataDir + ":/data"},
 		Logging: standardLogOptions,
+		Ports:   []string{fmt.Sprint(stack.ExposedGanachePort) + ":8545"},
 	}
 
 	for _, member := range stack.Members {
@@ -110,7 +111,7 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 		compose.Services["ipfs_"+member.ID] = &Service{
 			Image: "ipfs/go-ipfs",
 			Ports: []string{
-				fmt.Sprint(member.ExposedIPFSApiPort) + ":5000",
+				fmt.Sprint(member.ExposedIPFSApiPort) + ":5001",
 				fmt.Sprint(member.ExposedIPFSGWPort) + ":8080",
 			},
 			Environment: map[string]string{

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -436,16 +436,6 @@ func (s *Stack) patchConfigAndRestartFireflyNodes(verbose bool) error {
 	return nil
 }
 
-// func (s *Stack) restartFireflyNodes(verbose bool) error {
-// 	for _, member := range s.Members {
-// 		containerName := fmt.Sprintf("%s_firefly_core_%s_1", s.Name, member.ID)
-// 		if err := s.restartFireflyNode(containerName, verbose); err != nil {
-// 			return err
-// 		}
-// 	}
-// 	return nil
-// }
-
 func (s *Stack) stopFirelyNode(containerName string, verbose bool) error {
 	workingDir := path.Join(StacksDir, s.Name)
 	return docker.RunDockerCommand(workingDir, verbose, verbose, "stop", containerName)
@@ -455,11 +445,6 @@ func (s *Stack) startFireflyNode(containerName string, verbose bool) error {
 	workingDir := path.Join(StacksDir, s.Name)
 	return docker.RunDockerCommand(workingDir, verbose, verbose, "start", containerName)
 }
-
-// func (s *Stack) restartFireflyNode(containerName string, verbose bool) error {
-// 	workingDir := path.Join(StacksDir, s.Name)
-// 	return docker.RunDockerCommand(workingDir, verbose, verbose, "restart", containerName)
-// }
 
 func (s *Stack) extractContracts(containerName string, verbose bool) error {
 	workingDir := path.Join(StacksDir, s.Name)


### PR DESCRIPTION
- Exposes ports for all services, to aid running of firefly outside of compose
  - Fixes IPFS which was exposing port `5000` rather than `5001`
  - Avoids port `6000` which Chrome does not like querying (for when `/webui` is enabled for IPFS)
  - Allows commandline options `-p` and `-s` to configure the base ports
     - FireFly base port - default 5000 with increment of 1 for each member (5000,5001,5002 etc.)
     - Service base port - default 5100 with increment of 100 for each member (5100, 5200, 5300 etc.)
- Allows `docker pull` to be disabled during `ff start`, for developers with locally built images
  - `ff start -n mystack`
  - Will update the e2e test to use this