### PR TITLE
Improve ganache healthcheck and shorten timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ On earlier versions of Go:
 $ go get github.com/hyperledger-labs/firefly-cli/ff
 ```
 
+## Running on Linux
+
+There are a couple of things to be aware of if you're running the FireFly CLI on Linux:
+
+1. Because the FireFly CLI uses Docker, you may encounter some permission issues, depending on how your dev machine is set up. Unless you have set up your user to run Docker without root, it is recommended that you run FireFly CLI commands with `sudo`. For example, to create a new stack run:
+
+```
+$ sudo ff init <stack_name>
+```
+
+For more information about Docker permissions on Linux, please see [Docker's documentation on the topic](https://docs.docker.com/engine/install/linux-postinstall/).
+
+2. By default, `go install` will install the `ff` binary at `~/go/bin/ff`. If you are running `ff` with `sudo`, the root user will not be able to find the `ff` binary on the path. It is recommended to create a symlink so that the root user can find the `ff` binary on the path.
+
+```
+$ sudo ln -s ~/go/bin/ff /usr/bin/ff
+```
+
 ## Create a new stack
 
 ```
@@ -65,4 +83,20 @@ This command will completely delete a stack, including all of its data and confi
 
 ```
 $ ff remove <stack_name>
+```
+
+## Get stack info
+
+This command will print out information about a particular stack, including whether it is running or not.
+
+```
+$ ff info <stack_name>
+```
+
+## List all stacks
+
+This command will list all stacks that have been created on your machine.
+
+```
+$ ff ls
 ```

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -65,9 +65,9 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 		Volumes: []string{dataDir + ":/data"},
 		HealthCheck: &HealthCheck{
 			Test:     []string{"CMD-SHELL", "./healthcheck.sh"},
-			Interval: "10s",
-			Timeout:  "8s",
-			Retries:  6,
+			Interval: "4s",
+			Timeout:  "3s", // 1 second longer than the timeout in the script itself
+			Retries:  15,   // 15 * 4 second intervals = one minute
 		},
 		Logging: standardLogOptions,
 		Ports:   []string{fmt.Sprint(stack.ExposedGanachePort) + ":8545"},

--- a/internal/stacks/ganache/healthcheck.sh
+++ b/internal/stacks/ganache/healthcheck.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
-timeout 5s curl -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Host: localhost" -H "Origin: http://localhost:8545" -H "Sec-WebSocket-Key: super_secret_key" -H "Sec-WebSocket-Version: 13" http://localhost:8545
+GANACHE_PORT=8545
+TIMEOUT_CODE=143
 
-if [ $? -eq 143 ]; then exit 0; else exit 1; fi
+output=$(timeout 2s curl --stderr - -i -N -H "Connection: Upgrade" -H "Upgrade: websocket" -H "Host: localhost" -H "Origin: http://localhost:$GANACHE_PORT" -H "Sec-WebSocket-Key: super_secret_key" -H "Sec-WebSocket-Version: 13" http://localhost:$GANACHE_PORT)
+ret=$?
+
+if [ $ret -eq $TIMEOUT_CODE ]; then
+    echo $output | grep "101 Switching Protocols" >> /dev/null
+else
+    exit 1
+fi


### PR DESCRIPTION
This PR adds an extra step to the ganache healthcheck, using `grep` to make sure that we actually get an HTTP upgrade response for the websocket. The previous code just assumed that if it didn't exit immediately that it was successful, which is not always a safe assumption. This also allows us to shorten the timeouts a bit, which should shave a few seconds off the stack startup time.