### PR TITLE
Select between database implementations

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -94,6 +94,7 @@ func validateCount(input string) error {
 func init() {
 	initCmd.Flags().IntVarP(&initOptions.FireFlyBasePort, "firefly-base-port", "p", 5000, "Mapped port base of FireFly core API (1 added for each member)")
 	initCmd.Flags().IntVarP(&initOptions.ServicesBasePort, "services-base-port", "s", 5100, "Mapped port base of services (100 added for each member)")
+	initCmd.Flags().StringVarP(&initOptions.DatabaseSelection, "database", "d", "", fmt.Sprintf("Database type to use. Options are: %v", stacks.DBSelectionStrings))
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -76,21 +76,18 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 
 	for _, member := range stack.Members {
 
-		if stack.Database == "postgres" {
-			compose.Services["firefly_core_"+member.ID] = &Service{
-				Image: "ghcr.io/hyperledger-labs/firefly:latest",
-				Ports: []string{
-					fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
-					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminPort, member.ExposedFireflyAdminPort),
-				},
-				Volumes: []string{fmt.Sprintf("firefly_core_%s:/etc/firefly", member.ID)},
-				DependsOn: map[string]map[string]string{
-					"postgres_" + member.ID:     {"condition": "service_healthy"},
-					"ethconnect_" + member.ID:   {"condition": "service_started"},
-					"dataexchange_" + member.ID: {"condition": "service_started"},
-				},
-				Logging: standardLogOptions,
-			}
+		compose.Services["firefly_core_"+member.ID] = &Service{
+			Image: "ghcr.io/hyperledger-labs/firefly:latest",
+			Ports: []string{
+				fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
+				fmt.Sprintf("%d:%d", member.ExposedFireflyAdminPort, member.ExposedFireflyAdminPort),
+			},
+			Volumes: []string{fmt.Sprintf("firefly_core_%s:/etc/firefly", member.ID)},
+			DependsOn: map[string]map[string]string{
+				"ethconnect_" + member.ID:   {"condition": "service_started"},
+				"dataexchange_" + member.ID: {"condition": "service_started"},
+			},
+			Logging: standardLogOptions,
 		}
 
 		compose.Volumes["firefly_core_"+member.ID] = struct{}{}
@@ -114,6 +111,8 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 			}
 
 			compose.Volumes["postgres_"+member.ID] = struct{}{}
+
+			compose.Services["firefly_core_"+member.ID].DependsOn["postgres_"+member.ID] = map[string]string{"condition": "service_healthy"}
 		}
 
 		compose.Services["ethconnect_"+member.ID] = &Service{

--- a/internal/stacks/dockerConfig.go
+++ b/internal/stacks/dockerConfig.go
@@ -75,41 +75,46 @@ func CreateDockerCompose(stack *Stack) *DockerComposeConfig {
 	compose.Volumes["ganache"] = struct{}{}
 
 	for _, member := range stack.Members {
-		compose.Services["firefly_core_"+member.ID] = &Service{
-			Image: "ghcr.io/hyperledger-labs/firefly:latest",
-			Ports: []string{
-				fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
-				fmt.Sprintf("%d:%d", member.ExposedFireflyAdminPort, member.ExposedFireflyAdminPort),
-			},
-			Volumes: []string{fmt.Sprintf("firefly_core_%s:/etc/firefly", member.ID)},
-			DependsOn: map[string]map[string]string{
-				"postgres_" + member.ID:     {"condition": "service_healthy"},
-				"ethconnect_" + member.ID:   {"condition": "service_started"},
-				"dataexchange_" + member.ID: {"condition": "service_started"},
-			},
-			Logging: standardLogOptions,
+
+		if stack.Database == "postgres" {
+			compose.Services["firefly_core_"+member.ID] = &Service{
+				Image: "ghcr.io/hyperledger-labs/firefly:latest",
+				Ports: []string{
+					fmt.Sprintf("%d:%d", member.ExposedFireflyPort, member.ExposedFireflyPort),
+					fmt.Sprintf("%d:%d", member.ExposedFireflyAdminPort, member.ExposedFireflyAdminPort),
+				},
+				Volumes: []string{fmt.Sprintf("firefly_core_%s:/etc/firefly", member.ID)},
+				DependsOn: map[string]map[string]string{
+					"postgres_" + member.ID:     {"condition": "service_healthy"},
+					"ethconnect_" + member.ID:   {"condition": "service_started"},
+					"dataexchange_" + member.ID: {"condition": "service_started"},
+				},
+				Logging: standardLogOptions,
+			}
 		}
 
 		compose.Volumes["firefly_core_"+member.ID] = struct{}{}
 
-		compose.Services["postgres_"+member.ID] = &Service{
-			Image: "postgres",
-			Ports: []string{fmt.Sprintf("%d:5432", member.ExposedPostgresPort)},
-			Environment: map[string]string{
-				"POSTGRES_PASSWORD": "f1refly",
-				"PGDATA":            "/var/lib/postgresql/data/pgdata",
-			},
-			Volumes: []string{fmt.Sprintf("postgres_%s:/var/lib/postgresql/data", member.ID)},
-			HealthCheck: &HealthCheck{
-				Test:     []string{"CMD-SHELL", "pg_isready -U postgres"},
-				Interval: "5s",
-				Timeout:  "3s",
-				Retries:  12,
-			},
-			Logging: standardLogOptions,
-		}
+		if stack.Database == "postgres" {
+			compose.Services["postgres_"+member.ID] = &Service{
+				Image: "postgres",
+				Ports: []string{fmt.Sprintf("%d:5432", member.ExposedPostgresPort)},
+				Environment: map[string]string{
+					"POSTGRES_PASSWORD": "f1refly",
+					"PGDATA":            "/var/lib/postgresql/data/pgdata",
+				},
+				Volumes: []string{fmt.Sprintf("postgres_%s:/var/lib/postgresql/data", member.ID)},
+				HealthCheck: &HealthCheck{
+					Test:     []string{"CMD-SHELL", "pg_isready -U postgres"},
+					Interval: "5s",
+					Timeout:  "3s",
+					Retries:  12,
+				},
+				Logging: standardLogOptions,
+			}
 
-		compose.Volumes["postgres_"+member.ID] = struct{}{}
+			compose.Volumes["postgres_"+member.ID] = struct{}{}
+		}
 
 		compose.Services["ethconnect_"+member.ID] = &Service{
 			Image:     "ghcr.io/hyperledger-labs/firefly-ethconnect:latest",

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -81,10 +81,10 @@ type MigrationsConfig struct {
 }
 
 type DatabaseConfig struct {
-	Type     string          `yaml:"type,omitempty"`
-	Postgres *CommonDBConfig `yaml:"postgres,omitempty"`
-	SQLite3  *CommonDBConfig `yaml:"sqlite3,omitempty"`
-	SQLiteGo *CommonDBConfig `yaml:"sqlitego,omitempty"`
+	Type       string          `yaml:"type,omitempty"`
+	PostgreSQL *CommonDBConfig `yaml:"postgres,omitempty"`
+	SQLite3    *CommonDBConfig `yaml:"sqlite3,omitempty"`
+	SQLiteGo   *CommonDBConfig `yaml:"sqlitego,omitempty"`
 }
 
 type PublicStorageConfig struct {
@@ -175,18 +175,28 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 		case "postgres":
 			memberConfig.Database = &DatabaseConfig{
 				Type: "postgres",
-				Postgres: &CommonDBConfig{
+				PostgreSQL: &CommonDBConfig{
 					URL: "postgres://postgres:f1refly@postgres_" + member.ID + ":5432?sslmode=disable",
 					Migrations: &MigrationsConfig{
 						Auto: true,
 					},
 				},
 			}
-		case "sqlite3", "sqlitego":
+		case "sqlite3":
 			memberConfig.Database = &DatabaseConfig{
 				Type: stack.Database,
-				Postgres: &CommonDBConfig{
-					URL: "THIS IS WHERE I GOT TO...."
+				SQLite3: &CommonDBConfig{
+					URL: "/etc/firefly/db",
+					Migrations: &MigrationsConfig{
+						Auto: true,
+					},
+				},
+			}
+		case "sqlitego":
+			memberConfig.Database = &DatabaseConfig{
+				Type: stack.Database,
+				SQLiteGo: &CommonDBConfig{
+					URL: "/etc/firefly/db",
 					Migrations: &MigrationsConfig{
 						Auto: true,
 					},

--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -84,7 +84,6 @@ type DatabaseConfig struct {
 	Type       string          `yaml:"type,omitempty"`
 	PostgreSQL *CommonDBConfig `yaml:"postgres,omitempty"`
 	SQLite3    *CommonDBConfig `yaml:"sqlite3,omitempty"`
-	SQLiteGo   *CommonDBConfig `yaml:"sqlitego,omitempty"`
 }
 
 type PublicStorageConfig struct {
@@ -186,16 +185,6 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 			memberConfig.Database = &DatabaseConfig{
 				Type: stack.Database,
 				SQLite3: &CommonDBConfig{
-					URL: "/etc/firefly/db",
-					Migrations: &MigrationsConfig{
-						Auto: true,
-					},
-				},
-			}
-		case "sqlitego":
-			memberConfig.Database = &DatabaseConfig{
-				Type: stack.Database,
-				SQLiteGo: &CommonDBConfig{
 					URL: "/etc/firefly/db",
 					Migrations: &MigrationsConfig{
 						Auto: true,

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -39,6 +39,7 @@ type Stack struct {
 	Members            []*Member `json:"members,omitempty"`
 	SwarmKey           string    `json:"swarmKey,omitempty"`
 	ExposedGanachePort int       `json:"exposedGanachePort,omitempty"`
+	Database           string    `json:"database"`
 }
 
 type Member struct {

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -40,10 +40,9 @@ type DatabaseSelection int
 const (
 	PostgreSQL DatabaseSelection = iota
 	SQLite3
-	SQLiteGo
 )
 
-var DBSelectionStrings = []string{"postgres", "sqlite3", "sqlitego"}
+var DBSelectionStrings = []string{"postgres", "sqlite3"}
 
 func (db DatabaseSelection) String() string {
 	return DBSelectionStrings[db]


### PR DESCRIPTION
This PR adds the ability to select between the different database implementations available in FireFly. This is part of the `init` command. Example

```
ff init my_stack --database=sqlite3
```

Available options are: `[postgresql sqlite3 sqlitego]`