### PR TITLE
Fix default database selection

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -94,7 +94,7 @@ func validateCount(input string) error {
 func init() {
 	initCmd.Flags().IntVarP(&initOptions.FireFlyBasePort, "firefly-base-port", "p", 5000, "Mapped port base of FireFly core API (1 added for each member)")
 	initCmd.Flags().IntVarP(&initOptions.ServicesBasePort, "services-base-port", "s", 5100, "Mapped port base of services (100 added for each member)")
-	initCmd.Flags().StringVarP(&initOptions.DatabaseSelection, "database", "d", "", fmt.Sprintf("Database type to use. Options are: %v", stacks.DBSelectionStrings))
+	initCmd.Flags().StringVarP(&initOptions.DatabaseSelection, "database", "d", "sqlite3", fmt.Sprintf("Database type to use. Options are: %v", stacks.DBSelectionStrings))
 
 	rootCmd.AddCommand(initCmd)
 }


### PR DESCRIPTION
A small bug was recently introduced that sets the database selection to an empty string. This sets the default to `sqlite3` which was the intended behavior in the previous PR.