### PR TITLE
Set _busy_timeout=5000 by default

### DIFF
--- a/internal/stacks/fireflyConfig.go
+++ b/internal/stacks/fireflyConfig.go
@@ -185,7 +185,7 @@ func NewFireflyConfigs(stack *Stack) map[string]*FireflyConfig {
 			memberConfig.Database = &DatabaseConfig{
 				Type: stack.Database,
 				SQLite3: &CommonDBConfig{
-					URL: "/etc/firefly/db",
+					URL: "/etc/firefly/db?_busy_timeout=5000",
 					Migrations: &MigrationsConfig{
 						Auto: true,
 					},


### PR DESCRIPTION
With SQLite default parameters, the following error is reasonably likely under load:
```
{"error":"FF10116: Database insert failed: database is locked"}
```

Setting a `_busy_timeout` on the SQLite URL by default should reduce the likelihood of this.
Lots more interesting information here: https://github.com/mattn/go-sqlite3/issues/274