### PR TITLE
Check HTTP status code for contract deploy

### DIFF
--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"mime/multipart"
@@ -91,6 +92,9 @@ func PublishABI(ethconnectUrl string, contract *Contract) (*PublishAbiResponseBo
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%d %s", resp.StatusCode, responseBody)
+	}
 	var publishAbiResponse *PublishAbiResponseBody
 	json.Unmarshal(responseBody, &publishAbiResponse)
 	return publishAbiResponse, nil
@@ -130,6 +134,9 @@ func DeployContract(ethconnectUrl string, abiId string, fromAddress string, para
 	if err != nil {
 		return nil, err
 	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("%d %s", resp.StatusCode, responseBody)
+	}
 	var deployContractResponse *DeployContractResponseBody
 	json.Unmarshal(responseBody, &deployContractResponse)
 	return deployContractResponse, nil
@@ -161,6 +168,9 @@ func RegisterContract(ethconnectUrl string, abiId string, contractAddress string
 	responseBody, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 201 {
+		return nil, fmt.Errorf("%d %s", resp.StatusCode, responseBody)
 	}
 	var registerResponseBody *RegisterResponseBody
 	json.Unmarshal(responseBody, &registerResponseBody)

--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -416,7 +416,7 @@ func checkPortAvailable(port int) error {
 
 	if conn != nil {
 		defer conn.Close()
-		return fmt.Errorf("port %d is unavailable. please check to see if another process is listening on that port.", port)
+		return fmt.Errorf("port %d is unavailable. please check to see if another process is listening on that port", port)
 	}
 	return nil
 }
@@ -499,7 +499,6 @@ func (s *Stack) deployContracts(spin *spinner.Spinner, verbose bool) error {
 	var paymentContractAddress string
 	var fireflyContractAddress string
 	for _, member := range s.Members {
-		var fireflyAbiId string
 		ethconnectUrl := fmt.Sprintf("http://127.0.0.1:%v", member.ExposedEthconnectPort)
 		if !contractDeployed {
 			updateStatus(fmt.Sprintf("publishing payment ABI to '%s'", member.ID), spin)
@@ -533,19 +532,18 @@ func (s *Stack) deployContracts(spin *spinner.Spinner, verbose bool) error {
 
 			contractDeployed = true
 		} else {
-			// Just load the ABI
 			updateStatus(fmt.Sprintf("publishing FireFly ABI to '%s'", member.ID), spin)
 			publishFireflyResponse, err := contracts.PublishABI(ethconnectUrl, fireflyContract)
 			if err != nil {
 				return err
 			}
-			fireflyAbiId = publishFireflyResponse.ID
-		}
-		// Register as "firefly"
-		updateStatus(fmt.Sprintf("registering FireFly contract on '%s'", member.ID), spin)
-		_, err := contracts.RegisterContract(ethconnectUrl, fireflyAbiId, fireflyContractAddress, member.Address, "firefly", map[string]string{"paymentContract": paymentContractAddress})
-		if err != nil {
-			return err
+			fireflyAbiId := publishFireflyResponse.ID
+
+			updateStatus(fmt.Sprintf("registering FireFly contract on '%s'", member.ID), spin)
+			_, err = contracts.RegisterContract(ethconnectUrl, fireflyAbiId, fireflyContractAddress, member.Address, "firefly", map[string]string{"paymentContract": paymentContractAddress})
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
This also revealed that it's not necessary to separately call
RegisterContract if DeployContract was already called on the node with
registeredName (it returns 409 since the contract was already registered).

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>