### PR TITLE
Add helper script for mapping ports out of a FireFly stack

### DIFF
--- a/scripts/map_ports.py
+++ b/scripts/map_ports.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import argparse
+import re
+import os
+import subprocess
+import sys
+
+STACK_DIR = os.path.expanduser(os.path.join('~', '.firefly', 'stacks'))
+HOST_PORT_PATTERN = re.compile(r'([A-Za-z0-9._-]+):(\d{4})')
+
+def _run_docker_cmd(args):
+  p = subprocess.run(['docker'] + args, capture_output=True)
+  return p.stdout.decode().rstrip()
+
+def _find_docker_container(name):
+  return _run_docker_cmd(['ps', '--filter', 'name=' + name, '--format', '{{.ID}}'])
+
+def _find_docker_port(container_id, container_port):
+  output = _run_docker_cmd(['port', container_id])
+  for line in output.splitlines():
+    source, dest = line.split(' -> ')
+    source_port = re.search(r'(\d+)/', source).group(1)
+    dest_port = re.search(r':(\d+)', dest).group(1)
+    if source_port == container_port:
+      return dest_port
+  return None
+
+def main():
+  parser = argparse.ArgumentParser(
+    description=(
+      'Read a FireFly config file and map internal Docker ports to the '
+      'exposed ports on localhost.'
+    ))
+  parser.add_argument('name', help='name of a running FireFly CLI stack')
+  parser.add_argument(
+    '-i', '--index', help='0-based index of container in the stack (default=0)',
+    type=int, default=0, required=False)
+  args = parser.parse_args()
+
+  filename = os.path.join(
+    STACK_DIR, args.name, 'configs', 'firefly_core_%d.yml' % args.index)
+
+  with open(filename) as f:
+    for line in f.readlines():
+      match = HOST_PORT_PATTERN.search(line)
+      if match:
+        host = match.group(1)
+        port = match.group(2)
+        if host != 'localhost' and host != '127.0.0.1':
+          container_id = _find_docker_container(host)
+          if container_id:
+            mapped_port = _find_docker_port(container_id, port)
+            if mapped_port:
+              line = line.replace(
+                '%s:%s' % (host, port), 'localhost:%s' % mapped_port)
+      print(line, end='')
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
I don't know if this is the right place to put this, or if it's even something that needs to be committed. But I created it, and it's helping me do local development on FireFly, so I wanted to share.

My current local development steps are:
1. Create a stack using FireFly CLI (init with `-d postgres` and start with `-n`)
2. Run this script and output the config for firefly_core_0 to a new file
3. Stop the firefly_core_0 container
4. Run my own instance of FireFly with `go run main.go -f <generated-config-file>`

---

This script can be used to take a FireFly config file and replace
internal docker-compose ports with the mapped ports on localhost,
generating a new config file that can be exported.

It's most useful if you want to replace a container in a stack
with your own FireFly instance (often necessary during testing and
development on FireFly itself).

Signed-off-by: Andrew Richardson <andrew.richardson@kaleido.io>