### PR TITLE
Automatically rollback failed first time setup

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -59,6 +59,7 @@ This command will start a stack and run it in the background.
 
 func init() {
 	startCmd.Flags().BoolVarP(&startOptions.NoPull, "no-pull", "n", false, "Do not pull latest images when starting")
+	startCmd.Flags().BoolVarP(&startOptions.NoRollback, "no-rollback", "b", false, "Do not automatically rollback changes if first time setup fails")
 
 	rootCmd.AddCommand(startCmd)
 }

--- a/internal/stacks/fireflyIdentity.go
+++ b/internal/stacks/fireflyIdentity.go
@@ -99,6 +99,7 @@ func (s *Stack) registerFireflyIdentities(spin *spinner.Spinner, verbose bool) e
 		}
 
 		foundOrg := false
+		retries := 60
 		for !foundOrg {
 			type establishedOrg struct {
 				ID   string `json:"id"`
@@ -113,8 +114,11 @@ func (s *Stack) registerFireflyIdentities(spin *spinner.Spinner, verbose bool) e
 			for _, o := range orgs {
 				foundOrg = foundOrg || o.Name == orgName
 			}
-			if !foundOrg {
+			if !foundOrg && retries > 0 {
 				time.Sleep(1 * time.Second)
+				retries--
+			} else if !foundOrg && retries == 0 {
+				return fmt.Errorf("timeout error waiting to register %s and %s", orgName, nodeName)
 			}
 		}
 


### PR DESCRIPTION
* Add --no-rollback -b flag to change new rollback default behavior
* Add 60 second timeout on member registration
* Clean up logging on stack startup

Signed-off-by: Nicko Guyer <nicko.guyer@kaleido.io>

closes #70 