### PR TITLE
Add command line flag for customizing provider

### DIFF
--- a/internal/stacks/stack.go
+++ b/internal/stacks/stack.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
@@ -31,34 +30,13 @@ import (
 var homeDir, _ = os.UserHomeDir()
 var StacksDir = filepath.Join(homeDir, ".firefly", "stacks")
 
-type DatabaseSelection int
-
-const (
-	PostgreSQL DatabaseSelection = iota
-	SQLite3
-)
-
-var DBSelectionStrings = []string{"postgres", "sqlite3"}
-
-func (db DatabaseSelection) String() string {
-	return DBSelectionStrings[db]
-}
-
-func DatabaseSelectionFromString(s string) (DatabaseSelection, error) {
-	for i, dbSelection := range DBSelectionStrings {
-		if strings.ToLower(s) == dbSelection {
-			return DatabaseSelection(i), nil
-		}
-	}
-	return SQLite3, fmt.Errorf("\"%s\" is not a valid database selection. valid options are: %v", s, DBSelectionStrings)
-}
-
 type Stack struct {
-	Name            string    `json:"name,omitempty"`
-	Members         []*Member `json:"members,omitempty"`
-	SwarmKey        string    `json:"swarmKey,omitempty"`
-	ExposedGethPort int       `json:"exposedGethPort,omitempty"`
-	Database        string    `json:"database"`
+	Name               string    `json:"name,omitempty"`
+	Members            []*Member `json:"members,omitempty"`
+	SwarmKey           string    `json:"swarmKey,omitempty"`
+	ExposedGethPort    int       `json:"exposedGethPort,omitempty"`
+	Database           string    `json:"database"`
+	BlockchainProvider string    `json:"blockchainProvider"`
 }
 
 type Member struct {
@@ -83,11 +61,12 @@ type StartOptions struct {
 }
 
 type InitOptions struct {
-	FireFlyBasePort   int
-	ServicesBasePort  int
-	DatabaseSelection string
-	Verbose           bool
-	ExternalProcesses int
+	FireFlyBasePort    int
+	ServicesBasePort   int
+	DatabaseSelection  DatabaseSelection
+	Verbose            bool
+	ExternalProcesses  int
+	BlockchainProvider BlockchainProvider
 }
 
 func ListStacks() ([]string, error) {
@@ -110,18 +89,13 @@ func ListStacks() ([]string, error) {
 }
 
 func InitStack(stackName string, memberCount int, options *InitOptions) error {
-
-	dbSelection, err := DatabaseSelectionFromString(options.DatabaseSelection)
-	if err != nil {
-		return err
-	}
-
 	stack := &Stack{
-		Name:            stackName,
-		Members:         make([]*Member, memberCount),
-		SwarmKey:        GenerateSwarmKey(),
-		ExposedGethPort: options.ServicesBasePort,
-		Database:        dbSelection.String(),
+		Name:               stackName,
+		Members:            make([]*Member, memberCount),
+		SwarmKey:           GenerateSwarmKey(),
+		ExposedGethPort:    options.ServicesBasePort,
+		Database:           options.DatabaseSelection.String(),
+		BlockchainProvider: options.BlockchainProvider.String(),
 	}
 
 	for i := 0; i < memberCount; i++ {

--- a/internal/stacks/types.go
+++ b/internal/stacks/types.go
@@ -1,0 +1,68 @@
+// Copyright © 2021 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stacks
+
+import (
+	"fmt"
+	"strings"
+)
+
+type DatabaseSelection int
+
+const (
+	PostgreSQL DatabaseSelection = iota
+	SQLite3
+)
+
+var DBSelectionStrings = []string{"postgres", "sqlite3"}
+
+func (db DatabaseSelection) String() string {
+	return DBSelectionStrings[db]
+}
+
+func DatabaseSelectionFromString(s string) (DatabaseSelection, error) {
+	for i, dbSelection := range DBSelectionStrings {
+		if strings.ToLower(s) == dbSelection {
+			return DatabaseSelection(i), nil
+		}
+	}
+	return SQLite3, fmt.Errorf("\"%s\" is not a valid database selection. valid options are: %v", s, DBSelectionStrings)
+}
+
+type BlockchainProvider int
+
+const (
+	GoEthereum BlockchainProvider = iota
+	HyperledgerBesu
+	HyperledgerFabric
+	Corda
+)
+
+var BlockchainProviderStrings = []string{"geth", "besu", "fabric", "corda"}
+
+func (blockchainProvider BlockchainProvider) String() string {
+	return BlockchainProviderStrings[blockchainProvider]
+}
+
+func BlockchainProviderFromString(s string) (BlockchainProvider, error) {
+	for i, blockchainProviderSelection := range BlockchainProviderStrings {
+		if strings.ToLower(s) == blockchainProviderSelection {
+			return BlockchainProvider(i), nil
+		}
+	}
+	return GoEthereum, fmt.Errorf("\"%s\" is not a valid blockchain provider selection. valid options are: %v", s, BlockchainProviderStrings)
+}


### PR DESCRIPTION
This is a start for support for several different blockchain providers. This just adds the command line interface options to specify which provider you want. `geth` is the only valid option currently. It's also written to the `stack.json` now so future versions of the CLI should be able to read `stack.json` files created with this code and be able to load that stack.