### PR TITLE
Fix bugs with initialization and starting

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -74,6 +74,7 @@ var initCmd = &cobra.Command{
 		memberCount, _ := strconv.Atoi(memberCountInput)
 
 		initOptions.Verbose = verbose
+		initOptions.DatabaseSelection, _ = stacks.DatabaseSelectionFromString(databaseSelection)
 		if err := stackManager.InitStack(stackName, memberCount, &initOptions); err != nil {
 			return err
 		}

--- a/internal/docker/docker_config.go
+++ b/internal/docker/docker_config.go
@@ -114,7 +114,9 @@ func CreateDockerCompose(stack *types.Stack) *DockerComposeConfig {
 
 			compose.Volumes["postgres_"+member.ID] = struct{}{}
 
-			compose.Services["firefly_core_"+member.ID].DependsOn["postgres_"+member.ID] = map[string]string{"condition": "service_healthy"}
+			if service, ok := compose.Services[fmt.Sprintf("firefly_core_%v", *member.Index)]; ok {
+				service.DependsOn["postgres_"+member.ID] = map[string]string{"condition": "service_healthy"}
+			}
 		}
 
 		compose.Services["ipfs_"+member.ID] = &Service{


### PR DESCRIPTION
Fixes:

- PostgreSQL always being selected regardless of command line arguments
- SIGSEGV when using an external node
- SIGSEGV when using an external node with postgres
- Startup sequence not listening on correct port for external processes on first time startup