### PR TITLE
Add healthcheck for tokens

### DIFF
--- a/internal/stacks/stack_manager.go
+++ b/internal/stacks/stack_manager.go
@@ -129,7 +129,11 @@ func (s *StackManager) InitStack(stackName string, memberCount int, options *Ini
 		// Add a dependency so each firefly core container won't start up until dependencies are up
 		for _, member := range s.Stack.Members {
 			if service, ok := compose.Services[fmt.Sprintf("firefly_core_%v", *member.Index)]; ok {
-				service.DependsOn[serviceDefinition.ServiceName] = map[string]string{"condition": "service_started"}
+				condition := "service_started"
+				if serviceDefinition.Service.HealthCheck != nil {
+					condition = "service_healthy"
+				}
+				service.DependsOn[serviceDefinition.ServiceName] = map[string]string{"condition": condition}
 			}
 		}
 	}

--- a/internal/tokens/erc1155/erc1155_provider.go
+++ b/internal/tokens/erc1155/erc1155_provider.go
@@ -64,6 +64,9 @@ func (p *ERC1155Provider) GetDockerServiceDefinitions() []*docker.ServiceDefinit
 				DependsOn: map[string]map[string]string{
 					"ethconnect_" + member.ID: {"condition": "service_started"},
 				},
+				HealthCheck: &docker.HealthCheck{
+					Test: []string{"CMD", "curl", "http://localhost:3000/api"},
+				},
 				Logging: docker.StandardLogOptions,
 			},
 		})


### PR DESCRIPTION
This fixes a timing issue on starting a stack after it's been stopped. Also requires https://github.com/hyperledger-labs/firefly-tokens-erc1155/pull/20 to be merged.